### PR TITLE
Changed Markup to reveal spacebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker-compose up
 
 - authenticate with slack
 
-- once the model loads, <spacebar> sends a hand to the handraising channel
+- once the model loads, pressing \<spacebar\> sends a hand to the handraising channel
 
 ## automatic mode (expirimental)
 


### PR DESCRIPTION
Reading this readme was unclear because formatting wasn't displaying the most important detail. You have to press \<spacebar\> to do the trick. Changed the formatting for spacebar.